### PR TITLE
fix: add missing import for AtomicFlag for Xcode 26 build

### DIFF
--- a/Sources/Futura/Atomic/AtomicFlag.swift
+++ b/Sources/Futura/Atomic/AtomicFlag.swift
@@ -13,6 +13,7 @@
  limitations under the License. */
 
 import libkern
+import os.atomic
 
 public enum AtomicFlag {
     


### PR DESCRIPTION
- Added missing import `os.atomic` to ensure compatibility with Xcode 26. 